### PR TITLE
add option to automatically resolve latest Project-Env CLI version

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This plugin allows you to use Project-Env within Jenkins pipelines. See [Project
 node {
     withProjectEnv(
             // The Project-Env CLI version which should be used.
+            // If not configured, the latest version will be resolved automatically.
             cliVersion: string,
             // Whether to activate the debug mode in the Project-Env CLI. 
             // If not configured, the debug mode will be deactivated.

--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,10 @@
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>apache-httpcomponents-client-4-api</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.assertj</groupId>

--- a/src/main/java/io/jenkins/plugins/projectenv/WithProjectEnvStep.java
+++ b/src/main/java/io/jenkins/plugins/projectenv/WithProjectEnvStep.java
@@ -17,12 +17,17 @@ import java.util.Set;
 
 public class WithProjectEnvStep extends Step {
 
-    private final String cliVersion;
+    private String cliVersion;
     private boolean cliDebug;
     private String configFile = "project-env.toml";
 
     @DataBoundConstructor
-    public WithProjectEnvStep(String cliVersion) {
+    public WithProjectEnvStep() {
+        // noop
+    }
+
+    @DataBoundSetter
+    public void setCliVersion(String cliVersion) {
         this.cliVersion = cliVersion;
     }
 
@@ -38,7 +43,11 @@ public class WithProjectEnvStep extends Step {
 
     @Override
     public StepExecution start(StepContext stepContext) throws Exception {
-        return new WithProjectEnvStepExecution(stepContext, cliVersion, cliDebug, configFile);
+        if (cliVersion != null) {
+            return new WithProjectEnvStepExecution(stepContext, cliDebug, configFile, cliVersion);
+        }
+        
+        return new WithProjectEnvStepExecution(stepContext, cliDebug, configFile);
     }
 
     @Extension

--- a/src/main/java/io/jenkins/plugins/projectenv/WithProjectEnvStepExecution.java
+++ b/src/main/java/io/jenkins/plugins/projectenv/WithProjectEnvStepExecution.java
@@ -14,20 +14,31 @@ import io.jenkins.plugins.projectenv.toolinfo.ToolInfo;
 import io.jenkins.plugins.projectenv.toolinfo.ToolInfoParser;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang.StringUtils;
+import org.apache.http.Header;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.methods.RequestBuilder;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
 import org.jenkinsci.plugins.workflow.steps.BodyExecutionCallback;
 import org.jenkinsci.plugins.workflow.steps.EnvironmentExpander;
 import org.jenkinsci.plugins.workflow.steps.GeneralNonBlockingStepExecution;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 
 import javax.annotation.Nonnull;
+import java.io.IOException;
 import java.net.URI;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class WithProjectEnvStepExecution extends GeneralNonBlockingStepExecution {
+
+    private static final Pattern LATEST_CLI_VERSION_PATTERN = Pattern.compile(".+/v(.+)$");
 
     private static final String PROJECT_ENV_CLI_DOWNLOAD_PATTERN = "https://github.com/Project-Env/project-env-core/releases/download/v{0}/cli-{0}-{1}-{2}.{3}";
 
@@ -45,14 +56,18 @@ public class WithProjectEnvStepExecution extends GeneralNonBlockingStepExecution
 
     private static final String CLI_TARGET_ARCH_AMD_64 = "amd64";
 
-    private final String cliVersion;
+    private final String fixedCliVersion;
     private final boolean cliDebug;
     private final String configFile;
 
-    public WithProjectEnvStepExecution(StepContext stepContext, String cliVersion, boolean cliDebug, String configFile) {
+    public WithProjectEnvStepExecution(StepContext stepContext, boolean cliDebug, String configFile) {
+        this(stepContext, cliDebug, configFile, null);
+    }
+
+    public WithProjectEnvStepExecution(StepContext stepContext, boolean cliDebug, String configFile, String fixedCliVersion) {
         super(stepContext);
 
-        this.cliVersion = cliVersion;
+        this.fixedCliVersion = fixedCliVersion;
         this.cliDebug = cliDebug;
         this.configFile = configFile;
     }
@@ -110,7 +125,43 @@ public class WithProjectEnvStepExecution extends GeneralNonBlockingStepExecution
         String cliArchiveExtension = getCliArchiveExtension(agentInfo);
         String cliTargetArchitecture = getCliTargetArchitecture();
 
-        return MessageFormat.format(PROJECT_ENV_CLI_DOWNLOAD_PATTERN, cliVersion, cliTargetOs, cliTargetArchitecture, cliArchiveExtension);
+        return MessageFormat.format(PROJECT_ENV_CLI_DOWNLOAD_PATTERN, getCliVersion(), cliTargetOs, cliTargetArchitecture, cliArchiveExtension);
+    }
+
+    private String getCliVersion() {
+        if (fixedCliVersion != null) {
+            return fixedCliVersion;
+        }
+
+        return resolveLatestCliVersion();
+    }
+
+    private String resolveLatestCliVersion() {
+        try {
+            try (CloseableHttpClient httpClient = HttpClients.custom().disableRedirectHandling().build()) {
+                HttpUriRequest request = RequestBuilder.get().setUri("https://github.com/Project-Env/project-env-cli/releases/latest").build();
+                try (CloseableHttpResponse response = httpClient.execute(request)) {
+                    int statusCode = response.getStatusLine().getStatusCode();
+                    if (statusCode != 302) {
+                        throw new IllegalStateException("expected redirection, but got " + statusCode);
+                    }
+
+                    Header location = response.getFirstHeader("Location");
+                    if (location == null) {
+                        throw new IllegalStateException("no redirection location present");
+                    }
+
+                    Matcher matcher = LATEST_CLI_VERSION_PATTERN.matcher(location.getValue());
+                    if (!matcher.find()) {
+                        throw new IllegalStateException("failed to extract latest Project-Env CLI version from URL " + location.getValue());
+                    }
+
+                    return matcher.group(1);
+                }
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("failed to resolve latest Project-Env CLI version", e);
+        }
     }
 
     private String getCliTargetOs(AgentInfo agentInfo) {

--- a/src/test/java/io/jenkins/plugins/projectenv/WithProjectEnvStepTest.java
+++ b/src/test/java/io/jenkins/plugins/projectenv/WithProjectEnvStepTest.java
@@ -38,7 +38,7 @@ public class WithProjectEnvStepTest {
                 "node('slave') {\n" +
                 "  writeFile text: '''" + projectEnvConfigFileContent + "''', file: 'project-env.toml'\n" +
                 "  println \"PATH: ${env.PATH}\"\n" +
-                "  withProjectEnv(cliVersion: '3.4.1', cliDebug: true) {\n" +
+                "  withProjectEnv(cliDebug: true) {\n" +
                 "    println \"PATH: ${env.PATH}\"\n" +
                 "    sh 'java -version'\n" +
                 "    sh 'native-image --version'\n" +


### PR DESCRIPTION
Added option to automatically resolve the latest Project-Env CLI version.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
