### PR TITLE
Require Jenkins 2.479.3 and Jakarta EE 9

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -2,6 +2,6 @@
   <extension>
     <groupId>io.jenkins.tools.incrementals</groupId>
     <artifactId>git-changelist-maven-extension</artifactId>
-    <version>1.7</version>
+    <version>1.8</version>
   </extension>
 </extensions>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.78</version>
+        <version>5.18</version>
         <relativePath/>
     </parent>
 
@@ -19,9 +19,9 @@
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
 
-        <jenkins.version>2.401.3</jenkins.version>
-        <jenkins-tools-bom.artifactId>bom-2.401.x</jenkins-tools-bom.artifactId>
-        <jenkins-tools-bom.version>2745.vc7b_fe4c876fa_</jenkins-tools-bom.version>
+        <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
+        <jenkins.baseline>2.479</jenkins.baseline>
+        <jenkins.version>${jenkins.baseline}.3</jenkins.version>
 
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
 
@@ -37,8 +37,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>${jenkins-tools-bom.artifactId}</artifactId>
-                <version>${jenkins-tools-bom.version}</version>
+                <artifactId>bom-${jenkins.baseline}.x</artifactId>
+                <version>4948.vcf1d17350668</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/project-env.toml
+++ b/project-env.toml
@@ -2,7 +2,7 @@ tools_directory = ".tools"
 
 [jdk]
 distribution = "Temurin"
-distribution_version = "11.0.17+8"
+distribution_version = "17.0.15+6"
 
 [maven]
-version = "3.8.6"
+version = "3.9.10"

--- a/src/main/java/io/jenkins/plugins/projectenv/WithProjectEnvStepExecution.java
+++ b/src/main/java/io/jenkins/plugins/projectenv/WithProjectEnvStepExecution.java
@@ -1,5 +1,6 @@
 package io.jenkins.plugins.projectenv;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.Util;
@@ -25,7 +26,6 @@ import org.jenkinsci.plugins.workflow.steps.EnvironmentExpander;
 import org.jenkinsci.plugins.workflow.steps.GeneralNonBlockingStepExecution;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 
-import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
@@ -336,7 +336,7 @@ public class WithProjectEnvStepExecution extends GeneralNonBlockingStepExecution
         return EnvironmentExpander
                 .merge(getContext().get(EnvironmentExpander.class), new EnvironmentExpander() {
                     @Override
-                    public void expand(@Nonnull EnvVars originalEnvVars) {
+                    public void expand(@NonNull EnvVars originalEnvVars) {
                         originalEnvVars.overrideAll(projectEnvVars);
                     }
                 });

--- a/src/main/java/io/jenkins/plugins/projectenv/WithProjectEnvStepExecution.java
+++ b/src/main/java/io/jenkins/plugins/projectenv/WithProjectEnvStepExecution.java
@@ -196,29 +196,19 @@ public class WithProjectEnvStepExecution extends GeneralNonBlockingStepExecution
 
     private String getCliTargetOs(AgentInfo agentInfo) {
         OperatingSystem operatingSystem = agentInfo.getOperatingSystem();
-        switch (operatingSystem) {
-            case WINDOWS:
-                return CLI_TARGET_OS_WINDOWS;
-            case MACOS:
-                return CLI_TARGET_OS_MACOS;
-            case LINUX:
-                return CLI_TARGET_OS_LINUX;
-            default:
-                throw new IllegalArgumentException("unexpected value " + operatingSystem + " received");
-        }
+        return switch (operatingSystem) {
+            case WINDOWS -> CLI_TARGET_OS_WINDOWS;
+            case MACOS -> CLI_TARGET_OS_MACOS;
+            case LINUX -> CLI_TARGET_OS_LINUX;
+        };
     }
 
     private String getCliArchiveExtension(AgentInfo agentInfo) {
         OperatingSystem operatingSystem = agentInfo.getOperatingSystem();
-        switch (operatingSystem) {
-            case WINDOWS:
-                return CLI_ARCHIVE_EXTENSION_ZIP;
-            case MACOS:
-            case LINUX:
-                return CLI_ARCHIVE_EXTENSION_TAR_GZ;
-            default:
-                throw new IllegalArgumentException("unexpected value " + operatingSystem + " received");
-        }
+        return switch (operatingSystem) {
+            case WINDOWS -> CLI_ARCHIVE_EXTENSION_ZIP;
+            case MACOS, LINUX -> CLI_ARCHIVE_EXTENSION_TAR_GZ;
+        };
     }
 
     private String getCliTargetArchitecture() {

--- a/src/main/java/io/jenkins/plugins/projectenv/proc/ProcHelper.java
+++ b/src/main/java/io/jenkins/plugins/projectenv/proc/ProcHelper.java
@@ -50,7 +50,7 @@ public final class ProcHelper {
 
             return ImmutableProcResult.builder()
                     .exitCode(exitCode)
-                    .stdOutput(stdOutInputStream.toString(StandardCharsets.UTF_8.name()))
+                    .stdOutput(stdOutInputStream.toString(StandardCharsets.UTF_8))
                     .build();
         }
     }
@@ -59,7 +59,7 @@ public final class ProcHelper {
         PrintStream logger = StepContextHelper.getTaskListener(context).getLogger();
 
         Thread thread = new Thread(() -> {
-            try (Scanner scanner = new Scanner(stdErrInputStream, StandardCharsets.UTF_8.name())) {
+            try (Scanner scanner = new Scanner(stdErrInputStream, StandardCharsets.UTF_8)) {
                 while (scanner.hasNextLine()) {
                     logger.println(scanner.nextLine());
                 }

--- a/src/test/java/io/jenkins/plugins/projectenv/WithProjectEnvStepTest.java
+++ b/src/test/java/io/jenkins/plugins/projectenv/WithProjectEnvStepTest.java
@@ -1,5 +1,6 @@
 package io.jenkins.plugins.projectenv;
 
+import hudson.model.Descriptor;
 import hudson.model.Label;
 import hudson.model.Result;
 import org.apache.commons.io.IOUtils;
@@ -55,7 +56,7 @@ public class WithProjectEnvStepTest {
 
         WorkflowRun run = jenkins.assertBuildStatus(Result.SUCCESS, project.scheduleBuild2(0));
         assertThat(run.getLog())
-                // assert that the JDK (including native-image)  has been installed
+                // assert that the JDK (including native-image) has been installed
                 .contains("installing jdk...")
                 .contains("openjdk version \"17.0.9\" 2023-10-17")
                 .contains("native-image 17.0.9 2023-10-17")
@@ -94,11 +95,11 @@ public class WithProjectEnvStepTest {
     @WithTimeout(600)
     public void testStepExecutionWithNonExistingConfigFile() throws Exception {
         WorkflowJob project = jenkins.createProject(WorkflowJob.class);
-        project.setDefinition(createOsSpecificPipelineDefinition("" +
-                "node('slave') {\n" +
-                "  withProjectEnv(cliVersion: '3.4.1', cliDebug: true) {\n" +
-                "  }\n" +
-                "}"));
+        project.setDefinition(createOsSpecificPipelineDefinition("""
+                node('slave') {
+                  withProjectEnv(cliVersion: '3.4.1', cliDebug: true) {
+                  }
+                }"""));
 
         WorkflowRun run = jenkins.assertBuildStatus(Result.FAILURE, project.scheduleBuild2(0));
         assertThat(run.getLog()).contains("failed to install tools: FileNotFoundException");
@@ -108,7 +109,7 @@ public class WithProjectEnvStepTest {
         return IOUtils.toString(getClass().getResource(resource), StandardCharsets.UTF_8);
     }
 
-    private CpsFlowDefinition createOsSpecificPipelineDefinition(String pipelineDefinition) {
+    private CpsFlowDefinition createOsSpecificPipelineDefinition(String pipelineDefinition) throws Descriptor.FormException {
         return new CpsFlowDefinition(SystemUtils.IS_OS_WINDOWS ?
                 pipelineDefinition.replace("sh", "bat") :
                 pipelineDefinition, true);


### PR DESCRIPTION
## Require Jenkins 2.479.3 and Jakarta EE 9

Jenkins 2.479.3 provides Jakarta EE 9, Eclipse Jetty 12, Spring Security 6, and Java 17.

* Update plugin pom and baseline
* Remove deprecations
* Use Java 17 language features
* Minor cleanup

### Testing done

`mvn clean verify`

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed